### PR TITLE
Handle clipboard failures and install pynput

### DIFF
--- a/installation_bash.sh
+++ b/installation_bash.sh
@@ -10,8 +10,8 @@ echo "Aktiviere die virtuelle Umgebung..."
 source venv/bin/activate
 
 # 3. Installiere die Python-Pakete
-echo "Installiere PySide6 und pyperclip und openai..."
-pip install PySide6 pyperclip openai
+echo "Installiere PySide6, pyperclip, openai und pynput..."
+pip install PySide6 pyperclip openai pynput
 
 # HINWEIS FÜR LINUX:
 echo ""

--- a/installation_powershell.ps1
+++ b/installation_powershell.ps1
@@ -13,9 +13,8 @@ if (Test-Path $activation_script) {
     Write-Host "Virtuelle Umgebung aktiviert."
 
     # 3. Installiere die Python-Pakete
-    Write-Host "Installiere PySide6, pyperclip und openai..."
-    pip install PySide6 pyperclip
-    pip install openai
+    Write-Host "Installiere PySide6, pyperclip, openai und pynput..."
+    pip install PySide6 pyperclip openai pynput
 
     Write-Host ""
     Write-Host "Installation abgeschlossen."


### PR DESCRIPTION
## Summary
- add centralized clipboard helper methods so preset execution and copy actions surface clear errors instead of crashing when the clipboard backend is unavailable
- update the Home page copy button to use the shared helper and gracefully handle clipboard issues
- install the missing pynput dependency in the Bash and PowerShell setup scripts so global shortcuts also work when the app is not focused

## Testing
- python -m compileall frontend.py backend.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915df9909c48321ae242daf6d42ed07)