### PR TITLE
Fix literal braces in stylesheet string

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -1502,10 +1502,10 @@ class APIManager(QMainWindow):
         # Gemeinsames Stylesheet-Grundgerüst (Schriftfamilie, allgemeine Rundungen)
         common = f"""
             * {{ font-family: '{APP_FONT_FAMILY}', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 14px; }}
-            QLineEdit, QComboBox, QTextEdit, QKeySequenceEdit { padding: 10px 12px; }
-            QTextEdit { padding: 12px; }
-            QPushButton { border: none; }
-            QLabel#section_subtitle { color: rgba(148, 163, 184, 0.95); font-size: 15px; }
+            QLineEdit, QComboBox, QTextEdit, QKeySequenceEdit {{ padding: 10px 12px; }}
+            QTextEdit {{ padding: 12px; }}
+            QPushButton {{ border: none; }}
+            QLabel#section_subtitle {{ color: rgba(148, 163, 184, 0.95); font-size: 15px; }}
         """
 
         # Anwenden


### PR DESCRIPTION
## Summary
- escape the CSS braces inside the common stylesheet f-string so literal padding/border declarations are preserved

## Testing
- python -m compileall frontend.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e46b10808321816e74aac73a9e5f)