### PR TITLE
Handle pynput availability on macOS

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -1,8 +1,8 @@
 import sys
+import os
 import pyperclip
 import threading
 from typing import Optional
-import os
 try:
     from pynput import keyboard as _pynput_keyboard
     PYNPUT_AVAILABLE = True
@@ -783,8 +783,8 @@ class APIManager(QMainWindow):
 
     def _update_pynput_listener(self):
         """Starts or restarts the pynput GlobalHotKeys listener with current _global_hotkey_map."""
-        # Auf macOS oder wenn pynput nicht verfügbar ist: keine globalen Hotkeys starten
-        if not PYNPUT_AVAILABLE or sys.platform == "darwin":
+        # Nur starten, wenn pynput verfügbar ist
+        if not PYNPUT_AVAILABLE:
             return
 
         if not self.global_hotkeys_supported:
@@ -813,8 +813,8 @@ class APIManager(QMainWindow):
 
     def _register_global_hotkey(self, qt_shortcut: str, preset_index: int, canonical: str):
         """Adds or updates the mapping used by the pynput listener and restarts it."""
-        # Auf macOS oder ohne pynput keine globalen Hotkeys registrieren
-        if not PYNPUT_AVAILABLE or sys.platform == "darwin" or not qt_shortcut:
+        # Wenn kein pynput vorhanden oder kein Shortcut-String, abbrechen
+        if not PYNPUT_AVAILABLE or not qt_shortcut:
             return
 
         if not self.global_hotkeys_supported:
@@ -850,8 +850,8 @@ class APIManager(QMainWindow):
 
     def _register_visibility_global_hotkey(self, qt_shortcut: str):
         """Registriert den Sichtbarkeits-Shortcut auch global via pynput."""
-        # Auf macOS oder ohne pynput keine globalen Hotkeys registrieren
-        if not PYNPUT_AVAILABLE or sys.platform == "darwin" or not qt_shortcut:
+        # Aufrufen nur, wenn pynput verfügbar ist und ein Shortcut gesetzt wurde
+        if not PYNPUT_AVAILABLE or not qt_shortcut:
             return
 
         if not self.global_hotkeys_supported:
@@ -880,7 +880,7 @@ class APIManager(QMainWindow):
         self._update_pynput_listener()
 
     def _unregister_visibility_global_hotkey(self):
-        if not self.global_hotkeys_supported:
+        if not PYNPUT_AVAILABLE or not self.global_hotkeys_supported:
             return
         if self._visibility_pynput_key and self._visibility_pynput_key in self._global_hotkey_map:
             try:
@@ -1110,7 +1110,7 @@ class APIManager(QMainWindow):
         self.load_saved_shortcuts()
 
     def _unregister_global_hotkey(self, shortcut_key: str):
-        if not self.global_hotkeys_supported or not shortcut_key:
+        if not PYNPUT_AVAILABLE or not self.global_hotkeys_supported or not shortcut_key:
             return
         pynput_key = self._shortcut_to_pynput.pop(shortcut_key, None)
         if pynput_key and pynput_key in self._global_hotkey_map:

--- a/setup_hotkeys.py
+++ b/setup_hotkeys.py
@@ -1,0 +1,44 @@
+import os
+import stat
+import sys
+from textwrap import dedent
+
+# Name der Hauptdatei mit der main()-Funktion und dem Qt-Start.
+# Falls deine Hauptdatei anders heißt als 'main.py', setze diesen Namen entsprechend.
+MAIN_FILE = "frontend.py"
+
+def main():
+    project_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Wir erzeugen ein .command-Skript für macOS, das die App außerhalb von PyCharm startet
+    script_path = os.path.join(project_dir, "run_promptpilot.command")
+
+    # Pfad zum aktuellen Python-Interpreter
+    python_executable = sys.executable
+
+    script_content = dedent(f"""\
+        #!/bin/bash
+        cd "{project_dir}"
+
+        # Falls PYCHARM_HOSTED gesetzt ist, löschen,
+        # damit in der App PYNPUT_AVAILABLE = True bleibt und pynput verwendet wird
+        unset PYCHARM_HOSTED
+
+        "{python_executable}" "{MAIN_FILE}"
+        read -p "Drücke Enter, um dieses Fenster zu schließen..."
+    """)
+
+    with open(script_path, "w", encoding="utf-8") as f:
+        f.write(script_content)
+
+    # Ausführbar machen
+    st = os.stat(script_path)
+    os.chmod(script_path, st.st_mode | stat.S_IEXEC)
+
+    print("✅ Setup fertig.")
+    print(f"Starte deine App künftig mit: {script_path}")
+    print("Dann sollten die globalen Hotkeys mit pynput funktionieren (sofern macOS-Berechtigungen gesetzt sind).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- guard all pynput-related code so it is only used when pynput is available, allowing macOS users outside PyCharm to keep global hotkeys
- add a setup script that creates a macOS `.command` launcher which unsets PYCHARM_HOSTED so pynput keeps working

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f5c64ac083219e230e30ebb8dfed)