### PR TITLE
Handle mac accessibility trust failures

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -50,12 +50,17 @@ if sys.platform == "darwin" and PYNPUT_AVAILABLE:
                 try:
                     return bool(Quartz.AXIsProcessTrusted())
                 except Exception:
-                    return True
+                    # Wenn selbst das fehlschlägt, deaktivieren wir lieber globale Hotkeys,
+                    # damit macOS keinen Trace/BPT trap: 5 wegen fehlender Berechtigungen auslöst.
+                    return False
 
         MAC_ACCESSIBILITY_TRUSTED = _is_process_trusted()
-    except Exception:
-        # Wenn wir den Status nicht zuverlässig bestimmen können, deaktivieren wir nichts automatisch.
-        MAC_ACCESSIBILITY_TRUSTED = True
+        print(f"[DEBUG] macOS accessibility trusted: {MAC_ACCESSIBILITY_TRUSTED}")
+    except Exception as exc:
+        # Wenn wir den Status nicht ermitteln können, deaktivieren wir globale Hotkeys,
+        # um den oben beschriebenen Trace/BPT trap: 5 zu verhindern.
+        MAC_ACCESSIBILITY_TRUSTED = False
+        print(f"[WARN] Konnte macOS Accessibility-Status nicht ermitteln: {exc}", file=sys.stderr)
 
 
 # ===== HELPER FUNCTIONS (müssen vor den Klassen definiert sein) =====


### PR DESCRIPTION
## Summary
- treat macOS accessibility trust failures as untrusted so global hotkeys stay disabled instead of crashing
- add debug/warn logging and explanatory comments so users understand why accessibility access is required

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171e36fea8832189b039a15720b577)