### PR TITLE
Add macOS build script

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -1,32 +1,124 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PROJECT_ROOT="/Users/taavoci1/PycharmProjects/VA/PromptPilot-Vertiefungsarbeit-Cian-Vonlanthen-Malik-Zehnder"
+PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python3"
+SPEC_FILE="$PROJECT_ROOT/promptpilot.spec"
+BUILD_DIR="$PROJECT_ROOT/build"
+DIST_DIR="$PROJECT_ROOT/dist"
 APP_NAME="PromptPilot.app"
-SPEC_FILE="promptpilot.spec"
-BUILD_DIR="build"
-DIST_DIR="dist"
 APP_PATH="$DIST_DIR/$APP_NAME"
-RESOURCES_DIR="$APP_PATH/Contents/Resources/resources"
-MACOS_DIR="$APP_PATH/Contents/MacOS"
+DESKTOP_PATH="$HOME/Desktop"
+ICON_FILE="$PROJECT_ROOT/icon.icns"
+MAIN_SCRIPT="$PROJECT_ROOT/frontend.py"
 
-printf '===> Cleaning previous build artifacts...\n'
+if [[ ! -d "$PROJECT_ROOT" ]]; then
+  echo "Projektverzeichnis nicht gefunden: $PROJECT_ROOT" >&2
+  exit 1
+fi
+
+if [[ ! -f "$MAIN_SCRIPT" ]]; then
+  echo "Startskript nicht gefunden: $MAIN_SCRIPT" >&2
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "Python-Binary nicht gefunden: $PYTHON_BIN" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip
+python3 -m pip install pyinstaller
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+  cat <<'SPEC' > "$SPEC_FILE"
+# -*- mode: python ; coding: utf-8 -*-
+import os
+import sys
+from PyInstaller.utils.hooks import collect_submodules
+
+project_root = os.path.abspath(os.path.dirname(__file__))
+venv_path = os.path.join(project_root, '.venv')
+python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+site_packages = os.path.join(venv_path, 'lib', python_version, 'site-packages')
+pathex = [project_root]
+if os.path.isdir(site_packages):
+    pathex.append(site_packages)
+
+hiddenimports = []
+for pkg in ('PySide6', 'Quartz', 'pynput'):
+    try:
+        hiddenimports += collect_submodules(pkg)
+    except Exception:
+        pass
+
+block_cipher = None
+icon_file = os.path.join(project_root, 'icon.icns')
+
+a = Analysis(
+    ['frontend.py'],
+    pathex=pathex,
+    binaries=[],
+    datas=[],
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='PromptPilot',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+)
+app = BUNDLE(
+    exe,
+    name='PromptPilot.app',
+    icon=icon_file if os.path.exists(icon_file) else None,
+    bundle_identifier='com.promptpilot.app',
+)
+SPEC
+fi
+
 rm -rf "$BUILD_DIR" "$DIST_DIR"
+mkdir -p "$BUILD_DIR" "$DIST_DIR"
 
-printf '===> Running PyInstaller with %s...\n' "$SPEC_FILE"
-pyinstaller "$SPEC_FILE"
+pyinstaller promptpilot.spec --clean --noconfirm
 
-printf '===> Preparing resource directory...\n'
-mkdir -p "$RESOURCES_DIR"
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Build fehlgeschlagen – $APP_PATH wurde nicht erstellt." >&2
+  exit 1
+fi
 
-for resource in presets.json credentials.json settings.json backend.py; do
-    printf '     -> Installing %s into app resources...\n' "$resource"
-    cp "$resource" "$RESOURCES_DIR/"
-done
+mkdir -p "$DESKTOP_PATH"
+DESKTOP_APP="$DESKTOP_PATH/$APP_NAME"
+rm -rf "$DESKTOP_APP"
+cp -R "$APP_PATH" "$DESKTOP_PATH/"
 
-printf '===> Installing custom start launcher...\n'
-install -m 755 start "$MACOS_DIR/start"
+if [[ ! -d "$DESKTOP_APP" ]]; then
+  echo "Fehler beim Kopieren nach $DESKTOP_APP" >&2
+  exit 1
+fi
 
-printf '===> Applying custom Info.plist...\n'
-cp Info.plist "$APP_PATH/Contents/Info.plist"
-
-printf '===> Final app available at: %s\n' "$APP_PATH"
+echo "Build erfolgreich – neue PromptPilot.app wurde auf den Desktop kopiert."


### PR DESCRIPTION
## Summary
- replace the previous helper with a full `build_app.sh` script tailored for the macOS project path and virtual environment
- auto-generate a resilient `promptpilot.spec` when missing, including hidden imports and optional icon handling for PyInstaller
- clean and rebuild the app, then copy the resulting `PromptPilot.app` to the Desktop after removing the previous version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b25e3992883219737018ab0edc0b5)