### PR TITLE
Add mac status bar menu and tweak UI

### DIFF
--- a/hotkeys.py
+++ b/hotkeys.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 from typing import Callable, Dict, Optional
 
-try:
-    from pynput import keyboard
-except Exception:  # pragma: no cover - pynput may be unavailable in some envs
-    keyboard = None  # type: ignore
-
 from backend import get_platform
+
+if get_platform() == "windows":
+    try:
+        from pynput import keyboard
+    except Exception:  # pragma: no cover - pynput may be unavailable in some envs
+        keyboard = None  # type: ignore
+else:  # pragma: no cover - hotkeys disabled on non-Windows systems
+    keyboard = None  # type: ignore
 
 
 class GlobalHotkeyManager:


### PR DESCRIPTION
## Summary
- add a macOS-specific status bar menu that executes presets directly from the menu, shows native notifications, and only opens the GUI when the user chooses Einstellungen
- update the frontend bootstrapper to detect the current platform, disable global hotkeys on macOS, and reuse a shared tray notification helper while keeping the Windows tray menu/hotkeys intact
- tidy the UI spacing for the main layout, top navigation, and sidebar to better match macOS look-and-feel
- restrict the hotkey manager so pynput is only imported and used on Windows

## Testing
- python -m py_compile frontend.py mac_statusbar.py hotkeys.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5f61140483219abddaf45d0ba9c3)