### PR TITLE
Make window resizable and fix mac status menu

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -565,8 +565,9 @@ class APIManager(QMainWindow):
         super().__init__()
         self._platform = PLATFORM
         self.setWindowTitle("PromptPilot")
-        # Fenster auf feste Größe setzen (nicht veränderbar)
-        self.setFixedSize(1200, 700)
+        # Erlaube eine größere Standardgröße und verhindere unnötiges Scrollen
+        self.setMinimumSize(1200, 720)
+        self.resize(1380, 860)
 
         # Backend frühzeitig initialisieren, damit Einstellungen gelesen werden können
         self.backend = APIBackend()

--- a/mac_statusbar.py
+++ b/mac_statusbar.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Dict, Set, TYPE_CHECKING
 
 from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
@@ -9,6 +10,8 @@ from PySide6.QtGui import QAction, QCursor, QIcon
 from PySide6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 
 from backend import resource_path
+
+IS_NATIVE_MAC = sys.platform == "darwin"
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     from backend import APIBackend
@@ -150,10 +153,9 @@ class MacStatusBarApp(QObject):
             app.quit()
 
     def _handle_activation(self, reason: QSystemTrayIcon.ActivationReason) -> None:
-        # Showing the popup for every activation reason caused the menu to appear
-        # twice on macOS (the native menu plus our manual popup). Limiting the
-        # manual popup to left-clicks keeps the UX clean.
-        if reason == QSystemTrayIcon.Trigger:
+        # macOS zeigt das native Menü automatisch an, daher nur auf anderen
+        # Plattformen manuell öffnen.
+        if reason == QSystemTrayIcon.Trigger and not IS_NATIVE_MAC:
             self._menu.popup(QCursor.pos())
 
     def _load_icon(self) -> QIcon:


### PR DESCRIPTION
## Summary
- allow the main PromptPilot window to be resized and start with a larger default size so the full UI is visible without scrolling
- prevent the macOS status bar integration from manually popping up the tray menu so only the native menu is shown

## Testing
- python -m py_compile frontend.py mac_statusbar.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6b0fa614832189935c935c5c8152)