### PR TITLE
Update settings handler to open preset manager

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -790,7 +790,7 @@ class APIManager(QMainWindow):
         self.change_page(1)
 
     def open_settings(self):
-        self.open_api_settings()
+        self.open_preset_manager()
 
     def trigger_preset_by_index(self, index, shortcut_key: Optional[str] = None):
         """Safely trigger preset execution on the Qt main thread from background threads."""


### PR DESCRIPTION
## Summary
- update the top-bar settings handler to open the preset manager page
- ensure settings action lands on presets instead of API settings

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f164bacdc832184f4a08abf9bbeb7)