### PR TITLE
Use existing icon asset for tray icons

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -87,6 +87,7 @@ a = Analysis(
         (os.path.join(PROJECT_ROOT, 'presets.json'), '.'),
         (os.path.join(PROJECT_ROOT, 'settings.json'), '.'),
         (os.path.join(PROJECT_ROOT, 'credentials.json'), '.'),
+        (os.path.join(PROJECT_ROOT, 'promtpilot_icon.png'), 'resources'),
     ],
     hiddenimports=hiddenimports,
     hookspath=[],

--- a/frontend.py
+++ b/frontend.py
@@ -792,7 +792,7 @@ class APIManager(QMainWindow):
             self.statusbar_app.update_presets()
 
     def _load_tray_icon(self):
-        for icon_name in ("icon.icns", "icon.png"):
+        for icon_name in ("promtpilot_icon.icns", "promtpilot_icon.png", "icon.icns", "icon.png"):
             icon_path = resource_path(icon_name)
             if os.path.exists(icon_path):
                 icon = QIcon(icon_path)

--- a/mac_statusbar.py
+++ b/mac_statusbar.py
@@ -159,7 +159,7 @@ class MacStatusBarApp(QObject):
             self._menu.popup(QCursor.pos())
 
     def _load_icon(self) -> QIcon:
-        for icon_name in ("icon.icns", "icon.png"):
+        for icon_name in ("promtpilot_icon.icns", "promtpilot_icon.png", "icon.icns", "icon.png"):
             icon_path = resource_path(icon_name)
             if os.path.exists(icon_path):
                 icon = QIcon(icon_path)

--- a/promptpilot.spec
+++ b/promptpilot.spec
@@ -32,6 +32,7 @@ a = Analysis(
         (os.path.join(PROJECT_ROOT, 'presets.json'), '.'),
         (os.path.join(PROJECT_ROOT, 'settings.json'), '.'),
         (os.path.join(PROJECT_ROOT, 'credentials.json'), '.'),
+        (os.path.join(PROJECT_ROOT, 'promtpilot_icon.png'), 'resources'),
     ],
     hiddenimports=hiddenimports,
     hookspath=[],


### PR DESCRIPTION
## Summary
- remove the newly added `promptpilot_logo.png` binary and rely on the existing packaged icon
- package `promtpilot_icon.png` with the build so tray/status bar can load it
- update tray and mac status bar icon loaders to prefer the existing icon asset before legacy names

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1da5ce748321ab5e4762bb411b32)