### PR TITLE
Update preset library layout

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout, QHBoxLayout, QPushButton, QComboBox,
     QFrame, QScrollArea, QMessageBox, QStackedWidget,
     QTextEdit, QDialog, QSplitter, QKeySequenceEdit,
-    QSystemTrayIcon, QMenu, QStyle, QGridLayout, QSizePolicy
+    QSystemTrayIcon, QMenu, QStyle, QSizePolicy
 )
 
 
@@ -1790,11 +1790,10 @@ class HomePage(BasePage):
         self.presets_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         self.presets_container = QWidget()
-        self.presets_grid = QGridLayout()
-        self.presets_grid.setHorizontalSpacing(16)
-        self.presets_grid.setVerticalSpacing(16)
-        self.presets_grid.setContentsMargins(8, 12, 8, 12)
-        self.presets_container.setLayout(self.presets_grid)
+        self.presets_layout = QVBoxLayout()
+        self.presets_layout.setSpacing(16)
+        self.presets_layout.setContentsMargins(8, 12, 8, 12)
+        self.presets_container.setLayout(self.presets_layout)
         self.presets_scroll.setWidget(self.presets_container)
         library_layout.addWidget(self.presets_scroll, 1)
 
@@ -1915,10 +1914,6 @@ class HomePage(BasePage):
         self.main_splitter.setSizes([840, 360])
         self.main_layout.addWidget(self.main_splitter)
 
-        self._preset_grid_columns = self.calculate_preset_columns()
-        self.presets_scroll.viewport().installEventFilter(self)
-        self.presets_container.installEventFilter(self)
-
         self.current_search = ""
         self.update_presets_list()
     # --- Formular-Validierung ---
@@ -2022,28 +2017,10 @@ class HomePage(BasePage):
         self.result_card.hide()
 
     # --- Preset-Liste ---
-    def calculate_preset_columns(self) -> int:
-        """Ermittelt die Anzahl Spalten für das Preset-Grid basierend auf der verfügbaren Breite."""
-        spacing = self.presets_grid.horizontalSpacing() or 16
-        if spacing < 0:
-            spacing = 16
-        viewport_width = self.presets_scroll.viewport().width() or self.presets_scroll.width() or 640
-        card_target_width = 280
-        columns = max(1, (viewport_width + spacing) // (card_target_width + spacing))
-        return int(columns)
-
-    def eventFilter(self, obj, event):
-        if obj in (self.presets_scroll.viewport(), self.presets_container) and event.type() == QEvent.Type.Resize:
-            columns = self.calculate_preset_columns()
-            if columns != getattr(self, "_preset_grid_columns", columns):
-                self._preset_grid_columns = columns
-                self.update_presets_list()
-        return super().eventFilter(obj, event)
-
     def update_presets_list(self):
         # Alle Widgets entfernen
-        while self.presets_grid.count():
-            item = self.presets_grid.takeAt(0)
+        while self.presets_layout.count():
+            item = self.presets_layout.takeAt(0)
             widget = item.widget()
             if widget is not None:
                 widget.deleteLater()
@@ -2077,26 +2054,17 @@ class HomePage(BasePage):
             empty_text.setAlignment(Qt.AlignmentFlag.AlignCenter)
             empty_text.setObjectName("section_subtitle")
             empty_layout.addWidget(empty_text)
-            self.presets_grid.addWidget(empty, 0, 0)
-            self.presets_grid.setColumnStretch(0, 1)
-            self.presets_grid.setRowStretch(1, 1)
+            self.presets_layout.addWidget(empty)
+            self.presets_layout.addStretch(1)
             return
 
-        columns = max(1, getattr(self, "_preset_grid_columns", 1))
-        row = 0
-        col = 0
         for idx, preset in filtered:
             widget = self.create_preset_widget(idx, preset)
+            widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             widget.setMinimumWidth(260)
-            self.presets_grid.addWidget(widget, row, col)
-            col += 1
-            if col >= columns:
-                row += 1
-                col = 0
+            self.presets_layout.addWidget(widget)
 
-        for c in range(columns):
-            self.presets_grid.setColumnStretch(c, 1)
-        self.presets_grid.setRowStretch(row + 1, 1)
+        self.presets_layout.addStretch(1)
 
     def filter_presets(self, text: str):
         """Filtert die Preset-Liste basierend auf der Sucheingabe."""


### PR DESCRIPTION
## Summary
- display preset cards in a single vertical list with buttons below for a cleaner preset library
- adjust preset list refresh to work with the vertical layout and maintain empty state spacing

## Testing
- python -m compileall frontend.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f2d0db7ac83219bdbe87515564d38)