### PR TITLE
Handle missing OpenAI client initialization

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -123,9 +123,13 @@ class PromptPilotBackend:
             if api_key:
                 try:
                     self.client = openai.OpenAI(api_key=api_key)
-                    return True
+                    return self.client is not None
                 except Exception:
+                    self.client = None
                     return False
+            self.client = None
+            return False
+
         return bool(self._get_api_key(provider))
 
     def _infer_provider_model(self, preset: Dict) -> Tuple[str, str]:
@@ -388,6 +392,8 @@ class PromptPilotBackend:
         return result
 
     def _execute_openai(self, model: str, full_prompt: str) -> Dict[str, str]:
+        if not self.client and not self._init_client("OpenAI"):
+            return {"status": "fail", "message": "Could not initialize OpenAI client. Please check your credentials."}
         try:
             response = self.client.chat.completions.create(
                 model=model,


### PR DESCRIPTION
## Summary
- ensure OpenAI client initialization clears the client on failure and only reports success when the client exists
- add a safeguard in the OpenAI execution path to reinitialize the client or return a clearer error when credentials are missing

## Testing
- python -m compileall backend.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f31f568c08321900b694614ee9ed9)