### PR TITLE
Fix OpenAI client initialization case handling

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -116,10 +116,10 @@ class PromptPilotBackend:
         """Initialize SDK clients where applicable."""
 
         provider = provider or ""
-        provider_key = provider.title()
+        provider_key = provider.lower()
 
-        if provider_key == "OpenAI":
-            api_key = self._get_api_key(provider_key)
+        if provider_key == "openai":
+            api_key = self._get_api_key(provider)
             if api_key:
                 try:
                     self.client = openai.OpenAI(api_key=api_key)


### PR DESCRIPTION
## Summary
- normalize provider name comparison in `_init_client` to properly initialize the OpenAI client
- ensure credentials lookup uses the original provider string while respecting case-insensitive matches

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f33a158508321937430b6cd484fb5)