### PR TITLE
Add macOS push notifications for status bar presets

### DIFF
--- a/mac_statusbar.py
+++ b/mac_statusbar.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from typing import Dict, Set, TYPE_CHECKING
 
@@ -184,3 +185,16 @@ class MacStatusBarApp(QObject):
         title = f"{preset_name} abgeschlossen"
         body = message or "Preset erfolgreich beendet."
         self._notify(title, body, QSystemTrayIcon.Information)
+        if IS_NATIVE_MAC:
+            self._send_push_notification(title, body)
+
+    def _send_push_notification(self, title: str, message: str) -> None:
+        """Send a native macOS push notification for successful preset runs."""
+        try:
+            escaped_title = title.replace("\"", "\\\"")
+            escaped_message = message.replace("\"", "\\\"")
+            script = f'display notification "{escaped_message}" with title "{escaped_title}"'
+            subprocess.run(["osascript", "-e", script], check=False)
+        except Exception:
+            # If native notifications fail, silently ignore to not impact preset flow.
+            pass


### PR DESCRIPTION
## Summary
- add a native macOS push notification hook for presets executed from the status bar
- keep existing tray notifications while also invoking the system notification center on successful runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207851b1488321913b83de80fc2545)